### PR TITLE
Improved data provider cache and fixed environment declaration

### DIFF
--- a/data-provider.js
+++ b/data-provider.js
@@ -3,25 +3,33 @@ const path = require('path');
 
 module.exports = {
   cachedData: {},
-  getData(key) {
+  isFreshData(key) {
     if (!(key in this.cachedData)) {
-      const file = path.join(__dirname, `data/${key}.json`);
-      const data = fs.readFileSync(file, { encoding: 'utf8' });
-
-      this.cachedData[key] = JSON.parse(data);
+      return false;
     }
 
-    return this.cachedData[key];
+    const { dtime } = this.cachedData[key];
+    const { mtime } = fs.statSync(this.getPathData(key));
+
+    return mtime < dtime;
+  },
+  getPathData(key) {
+    return path.join(__dirname, `data/${key}.json`);
+  },
+  getData(key) {
+    if (!this.isFreshData(key)) {
+      const data = fs.readFileSync(this.getPathData(key), { encoding: 'utf8' });
+
+      this.cachedData[key] = {
+        data: JSON.parse(data),
+        dtime: new Date(),
+      };
+    }
+
+    return this.cachedData[key].data;
   },
   getDataById(key, id) {
-    return this.getData(key).reduce((model, next) => {
-      const { _id = '' } = next;
-      if (_id === id) {
-        return next;
-      }
-
-      return model;
-    }, null);
+    return this.getData(key).find(({ _id = '' }) => _id === id);
   },
   getCards() {
     return this.getData('cards');

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "main": "app.js",
   "scripts": {
-    "start": "PORT=${PORT:-3000} NODE_ENV=production node app.js",
-    "dev": "PORT=${PORT:-3000} NODE_ENV=development nodemon app.js"
+    "start": "PORT=3000 NODE_ENV=production node app.js",
+    "dev": "PORT=3000 NODE_ENV=development nodemon app.js"
   },
   "author": "Olga Miliukova",
   "license": "MIT",
@@ -15,6 +15,7 @@
     "nodemon": "^2.0.1"
   },
   "dependencies": {
+    "cross-env": "^6.0.3",
     "express": "^4.17.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,6 +313,13 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+cross-env@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
+  integrity sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
+  dependencies:
+    cross-spawn "^7.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -332,6 +339,15 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -1465,6 +1481,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
@@ -1730,10 +1751,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -2039,6 +2072,13 @@ which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
@Boortcore , здравствуйте

По поводу pull request, в задании написано, что сначала сделать git init, а потом приступить к реализации. Поэтому получилось так, что когда делала git push на github, то изменений для pull request уже не было

Далее по списку:

- Исправлено объявление "PORT=3000" в package.json. Изначально задумка была в том, чтобы использовать параметризированный вызов `PORT=3003 yarn start`, поэтому использовала так `PORT=${PORT:-3000}`
- Добавлен cross-env
- Улучшен data-provider. Теперь кешируемые данные инвалидируются при обновлении json-файлов. Оставила реализацию с data-provider, так как загрузка через require кеширует данные один раз без инвалидации

Спасибо за ревью. Жду проверки!
